### PR TITLE
Remove test utils file from test/index.ts

### DIFF
--- a/src/components/ConferenceDetails/ConferenceDetails.spec.tsx
+++ b/src/components/ConferenceDetails/ConferenceDetails.spec.tsx
@@ -3,7 +3,7 @@ import toJSON from 'enzyme-to-json'
 
 import { shallow } from 'enzyme'
 
-import { mockConference } from 'utils'
+import { mockConference } from 'utils/test'
 import { ConferenceDetails } from './ConferenceDetails'
 
 describe('ConferenceDetails', () => {

--- a/src/components/Header/Header.spec.tsx
+++ b/src/components/Header/Header.spec.tsx
@@ -3,7 +3,7 @@ import toJSON from 'enzyme-to-json'
 import { mount } from 'enzyme'
 
 import { Header } from './Header'
-import { wrapWithMemoryRouter } from 'utils'
+import { wrapWithMemoryRouter } from 'utils/test'
 
 describe('Header', () => {
   it('should render', () => {

--- a/src/components/List/List.spec.tsx
+++ b/src/components/List/List.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { shallow } from 'enzyme'
 import toJSON from 'enzyme-to-json'
 
-import { mockConference } from 'utils'
+import { mockConference } from 'utils/test'
 
 import { List } from './List'
 

--- a/src/components/Logo/Logo.spec.tsx
+++ b/src/components/Logo/Logo.spec.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import toJSON from 'enzyme-to-json'
 
 import { Logo } from './Logo'
-import { wrapWithMemoryRouter } from 'utils'
+import { wrapWithMemoryRouter } from 'utils/test'
 
 describe('Logo', () => {
   it('should render', () => {

--- a/src/components/Pages/FrontPage/FrontPage.spec.tsx
+++ b/src/components/Pages/FrontPage/FrontPage.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 
-import { shallowWithStore, mockConference } from 'utils'
+import { shallowWithStore, mockConference } from 'utils/test'
 import { FrontPage, FrontPageInner } from './FrontPage'
 
 describe('FrontPage', () => {

--- a/src/components/ResultDetails/ResultDetails.spec.tsx
+++ b/src/components/ResultDetails/ResultDetails.spec.tsx
@@ -3,7 +3,7 @@ import toJSON from 'enzyme-to-json'
 import { mount } from 'enzyme'
 
 import { ResultDetails } from './ResultDetails'
-import { mockIndexedConferences } from 'utils'
+import { mockIndexedConferences } from 'utils/test'
 
 describe('ResultDetails', () => {
   it('should render', () => {

--- a/src/components/Video/Video.spec.tsx
+++ b/src/components/Video/Video.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import toJSON from 'enzyme-to-json'
 
-import { mountWithStore, mockConference, mockVideo, wrapWithMemoryRouter } from 'utils'
+import { mountWithStore, mockConference, mockVideo, wrapWithMemoryRouter } from 'utils/test'
 import { VideoInner } from './Video'
 import { Conference } from '../../domain'
 

--- a/src/redux/modules/bootstrap.spec.ts
+++ b/src/redux/modules/bootstrap.spec.ts
@@ -1,5 +1,5 @@
 import 'rxjs'
-import { mockStore } from 'utils'
+import { mockStore } from 'utils/test'
 import { ActionsObservable } from 'redux-observable'
 
 import bootstrapReducer, {

--- a/src/redux/modules/routing.spec.ts
+++ b/src/redux/modules/routing.spec.ts
@@ -1,7 +1,7 @@
 import { take, toArray } from 'rxjs/operators'
 import { ActionsObservable } from 'redux-observable'
 
-import { mockStore, mockRouterState } from 'utils'
+import { mockStore, mockRouterState } from 'utils/test'
 
 import { conferencePageActions } from './conferencePage'
 import { searchActions } from './search'

--- a/src/redux/modules/search.spec.ts
+++ b/src/redux/modules/search.spec.ts
@@ -5,7 +5,7 @@ import { ActionsObservable } from 'redux-observable'
 import {
   mockStore, mockDataState,
   mockConferencePageSlice, mockRouterState, mockIndexedConferences
-} from 'utils'
+} from 'utils/test'
 
 import searchReducer, {
   textInDetails, initialState,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,2 @@
-export * from './test'
 export * from './search'
 export * from './url'


### PR DESCRIPTION
Removing test.ts from utils/index.ts, and chaning imports
to directly reference utils/test.ts, means that the test utils
file, and thus shallow and mount from enzyme, along with it's
own dependency of cheerio, are not bundled into the vendors chunk.

This reduces the vendor.js bundle from 833KB to 312 KB.